### PR TITLE
Include copyright information and consistent file headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ before_install:
 
 script:
   - stylelint --quiet sass/*.scss
-  - sass sass/gwbootstrap.scss gwbootstrap.css && rm -f gwbootstrap.css
+  - sass --style compressed sass/gwbootstrap.scss
   - acorn --silent js/*.js

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include README.rst LICENSE MANIFEST.in
+recursive-include sass *.scss
+recursive-include js *.js

--- a/js/gwbootstrap.js
+++ b/js/gwbootstrap.js
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) Duncan Macleod (2015)
+ *
+ * This file is part of GW-Bootstrap
+ *
+ * GW-Bootstrap is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * GW-Bootstrap is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GW-Bootstrap.  If not, see <http://www.gnu.org/licenses/>
+ */
+
 /** match page position to navbar height */
 function matchPageTopToNavbar() {
   $('.navbar-fixed-top + .container').css('padding-top', $('header').height());

--- a/sass/_banner.scss
+++ b/sass/_banner.scss
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) Duncan Macleod (2015)
+ *
+ * This file is part of GW-Bootstrap
+ *
+ * GW-Bootstrap is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * GW-Bootstrap is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GW-Bootstrap.  If not, see <http://www.gnu.org/licenses/>
+ */
+
 // _banner.scss
 // page header styles
 

--- a/sass/_calendar.scss
+++ b/sass/_calendar.scss
@@ -1,5 +1,24 @@
-/* ------------------------------------------------------------------------- */
-/* CALENDAR                                                                  */
+/*
+ * Copyright (C) Duncan Macleod (2015)
+ *
+ * This file is part of GW-Bootstrap
+ *
+ * GW-Bootstrap is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * GW-Bootstrap is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GW-Bootstrap.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+// _calendar.scss
+// styling for calendar navigation objects
 
 .navbar {
   #calendar,

--- a/sass/_code.scss
+++ b/sass/_code.scss
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) Duncan Macleod (2015)
+ *
+ * This file is part of GW-Bootstrap
+ *
+ * GW-Bootstrap is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * GW-Bootstrap is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GW-Bootstrap.  If not, see <http://www.gnu.org/licenses/>
+ */
+
 // _code.scss
 // styling for <pre> and <code> blocks
 

--- a/sass/_fancybox.scss
+++ b/sass/_fancybox.scss
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) Duncan Macleod (2015)
+ *
+ * This file is part of GW-Bootstrap
+ *
+ * GW-Bootstrap is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * GW-Bootstrap is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GW-Bootstrap.  If not, see <http://www.gnu.org/licenses/>
+ */
+
 // _fancybox.scss
 // styling for fancyboxes
 

--- a/sass/_footer.scss
+++ b/sass/_footer.scss
@@ -1,4 +1,24 @@
+/*
+ * Copyright (C) Duncan Macleod (2015)
+ *
+ * This file is part of GW-Bootstrap
+ *
+ * GW-Bootstrap is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * GW-Bootstrap is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GW-Bootstrap.  If not, see <http://www.gnu.org/licenses/>
+ */
+
 // _footer.scss
+// styling for bootstrap footer
 
 $footer-height: 140px;
 $footer-padding: 20px;

--- a/sass/_ifos.scss
+++ b/sass/_ifos.scss
@@ -1,4 +1,24 @@
-// _ifos.scss - IFO-specific colour schemes
+/*
+ * Copyright (C) Duncan Macleod (2015)
+ *
+ * This file is part of GW-Bootstrap
+ *
+ * GW-Bootstrap is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * GW-Bootstrap is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GW-Bootstrap.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+// _ifos.scss
+// IFO-specific colour schemes
 
 // set colour scheme for each IFO
 .navbar-h1 { @include navbar-colour-scheme(#ee0000); }  // LIGO Hanford

--- a/sass/_images.scss
+++ b/sass/_images.scss
@@ -1,4 +1,24 @@
+/*
+ * Copyright (C) Duncan Macleod (2015)
+ *
+ * This file is part of GW-Bootstrap
+ *
+ * GW-Bootstrap is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * GW-Bootstrap is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GW-Bootstrap.  If not, see <http://www.gnu.org/licenses/>
+ */
+
 // _image.scss
+// styling for SVG images
 
 .svg-wrapper {
   max-height: 600px;

--- a/sass/_mixins.scss
+++ b/sass/_mixins.scss
@@ -1,4 +1,24 @@
+/*
+ * Copyright (C) Duncan Macleod (2015)
+ *
+ * This file is part of GW-Bootstrap
+ *
+ * GW-Bootstrap is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * GW-Bootstrap is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GW-Bootstrap.  If not, see <http://www.gnu.org/licenses/>
+ */
+
 // _mixins.scss
+// styling mixins
 
 @mixin no-text-select() {
   user-select: none;

--- a/sass/_navbar.scss
+++ b/sass/_navbar.scss
@@ -1,4 +1,24 @@
-// Bootstrap navbar for LIGO
+/*
+ * Copyright (C) Duncan Macleod (2015)
+ *
+ * This file is part of GW-Bootstrap
+ *
+ * GW-Bootstrap is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * GW-Bootstrap is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GW-Bootstrap.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+// _navbar.scss
+// styling for bootstrap navigation bar
 
 $navbar-background-color: #555;
 $navbar-background-color-dark: darken($navbar-background-color, 5%);

--- a/sass/_page.scss
+++ b/sass/_page.scss
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) Duncan Macleod (2015)
+ *
+ * This file is part of GW-Bootstrap
+ *
+ * GW-Bootstrap is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * GW-Bootstrap is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GW-Bootstrap.  If not, see <http://www.gnu.org/licenses/>
+ */
+
 // _page.scss
 // basic page definitions
 

--- a/sass/_panels.scss
+++ b/sass/_panels.scss
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) Duncan Macleod (2015)
+ *
+ * This file is part of GW-Bootstrap
+ *
+ * GW-Bootstrap is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * GW-Bootstrap is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GW-Bootstrap.  If not, see <http://www.gnu.org/licenses/>
+ */
+
 // _panels.scss
 // styling for accordion panels
 

--- a/sass/_scaffolding.scss
+++ b/sass/_scaffolding.scss
@@ -1,4 +1,24 @@
+/*
+ * Copyright (C) Duncan Macleod (2015)
+ *
+ * This file is part of GW-Bootstrap
+ *
+ * GW-Bootstrap is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * GW-Bootstrap is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GW-Bootstrap.  If not, see <http://www.gnu.org/licenses/>
+ */
+
 // _scaffold.scss
+// styling for image scaffolding
 
 .scaffold {
   background-color: #fff;

--- a/sass/_tables.scss
+++ b/sass/_tables.scss
@@ -1,5 +1,24 @@
-/* ------------------------------------------------------------------------- */
-/* Table                                                                     */
+/*
+ * Copyright (C) Duncan Macleod (2015)
+ *
+ * This file is part of GW-Bootstrap
+ *
+ * GW-Bootstrap is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * GW-Bootstrap is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GW-Bootstrap.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+// _tables.scss
+// styling for HTML tables
 
 table {
   tr > tdiv {

--- a/sass/_variables.scss
+++ b/sass/_variables.scss
@@ -1,4 +1,24 @@
+/*
+ * Copyright (C) Duncan Macleod (2015)
+ *
+ * This file is part of GW-Bootstrap
+ *
+ * GW-Bootstrap is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * GW-Bootstrap is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GW-Bootstrap.  If not, see <http://www.gnu.org/licenses/>
+ */
+
 // _variables.scss
+// global variables for container size
 
 $container-sm: 768px;
 $container-md: 992px;

--- a/sass/gwbootstrap.scss
+++ b/sass/gwbootstrap.scss
@@ -1,4 +1,23 @@
-// Bootstrap CSS extensions for LIGO HTML
+/*
+ * Copyright (C) Duncan Macleod (2015)
+ *
+ * This file is part of GW-Bootstrap
+ *
+ * GW-Bootstrap is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * GW-Bootstrap is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GW-Bootstrap.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+// Bootstrap CSS extensions for GW observatories
 
 @charset 'utf-8';
 


### PR DESCRIPTION
This PR adds copyright information to the header of all SCSS and JS files, and includes a `MANIFEST.in` file in the top-level directory.

The copyright boilerplate assigns copyright to "Duncan Macleod (2015)".

cc @duncanmmacleod 