### PR TITLE
Restore fancybox-3.5.7 dependence, and bump version number to 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ in your HTML:
 <script src="https://cdn.jsdelivr.net/npm/gwbootstrap@<version>/lib/gwbootstrap.min.js" type="text/javascript"></script>
 ```
 
-where `<version>` is the semantic version number, e.g. 1.1.0.
+where `<version>` is the semantic version number, e.g. 1.2.0.
 
 A heavier collection of more interactive features, including calendar
 view and a figure overlay tool, is available from the `gwbootstrap-extra`
@@ -77,7 +77,7 @@ order is important).
 <tr class="odd">
 <td><strong>JavaScript</strong></td>
 <td>jquery-3.4.1<br>
-jquery-lazy-1.7.9<br>
+jquery-lazy-1.7.10<br>
 bootstrap-4.4.1<br>
 fancybox-3.5.7<br>
 gwbootstrap.min.js</td>

--- a/package-lock.json
+++ b/package-lock.json
@@ -283,6 +283,11 @@
         }
       }
     },
+    "@fancyapps/fancybox": {
+      "version": "3.5.7",
+      "resolved": "https://registry.npmjs.org/@fancyapps/fancybox/-/fancybox-3.5.7.tgz",
+      "integrity": "sha512-rcEtu8t+WnmqIDV/Wfm1yvy/nDdwc7YV25j9HLxGC2/WOsUhk9rcWg2nB8g1BrjRt9zaoADdjHTU6ILYTJzBBg=="
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -2087,11 +2092,6 @@
       "requires": {
         "is-extglob": "^1.0.0"
       }
-    },
-    "fancybox": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/fancybox/-/fancybox-3.0.1.tgz",
-      "integrity": "sha512-HZ57O6j5Zk4Uvusd5pNUgWi7CCjKx+HFlCzjMPeRJ//0bQWUK+xVpkn3EzXWJate4ZSKNFP9kU2l49MP1g+oow=="
     },
     "fast-deep-equal": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gwbootstrap",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Extensions to standard Bootstrap stylesheets for gravitational wave observatories",
   "main": "lib/gwbootstrap.min.js",
   "files": [
@@ -61,7 +61,7 @@
     "moment": "^2.24.0",
     "popper.js": "^1.16.0",
     "bootstrap": "^4.4.1",
-    "fancybox": "^3.0.1",
+    "@fancyapps/fancybox": "^3.5.7",
     "bootstrap-datepicker": "^1.9.0",
     "google-fonts": "^1.0.0"
   }


### PR DESCRIPTION
This PR corrects a mistake introduced in #14 by restoring a package dependence on fancybox-3.5.7. (The issue had been that fancybox has been moved under the `@fancyapps` namespace in NPM, so the software I was using to track package versions got fooled.)

This also bumps the version number to 1.2.0 in anticipation of an imminent release.

cc @duncanmmacleod 