### PR TITLE
Bump version number to 1.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ in your HTML:
 <script src="https://cdn.jsdelivr.net/npm/gwbootstrap@<version>/lib/gwbootstrap.min.js" type="text/javascript"></script>
 ```
 
-where `<version>` is the semantic version number, e.g. 1.2.0.
+where `<version>` is the semantic version number, e.g. 1.2.1.
 
 A heavier collection of more interactive features, including calendar
 view and a figure overlay tool, is available from the `gwbootstrap-extra`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gwbootstrap",
-  "version": "1.1.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gwbootstrap",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Extensions to standard Bootstrap stylesheets for gravitational wave observatories",
   "main": "lib/gwbootstrap.min.js",
   "files": [


### PR DESCRIPTION
This PR bumps the self version number to 1.2.1 in anticipation of a point release.

cc @duncanmmacleod 