### PR TITLE
Fix dropdown menu alignment for large menus on small screen

### DIFF
--- a/js/gwbootstrap-extra.js
+++ b/js/gwbootstrap-extra.js
@@ -343,7 +343,7 @@ jQuery(window).on('load', function () {
     const dropwidth = target.width();
     const left = jQuery(window).width();
     if (dropleft + dropwidth > left) {
-      target.addClass('dropdown-menu-right');
+      target.addClass('dropdown-menu-end');
     }
   });
 


### PR DESCRIPTION
This PR fixes a UI problem where a large dropdown menu could end up falling off screen. There was already some code to do this, but with the update to Bootstrap 5, the name of the property to right align changed to `dropdown-menu-end`.

I searched the project for other instances of this property and this was the only remaining item.