### PR TITLE
Move date fancybox for Summary Pages

### DIFF
--- a/js/gwbootstrap-extra.js
+++ b/js/gwbootstrap-extra.js
@@ -403,13 +403,13 @@ jQuery(window).on('load', function () {
         items: {
             ...(isCalendarFormat() && {
                 previousDay: {
-                  tpl: createButton('previousDay', 'Previous Date', 'M25 10 L15 20 L25 30'), 
+                  tpl: createButton('previousDate', 'Previous Date', 'M25 10 L15 20 L25 30'), 
                   click: () => {
                         stepDate(-1);
                     },
                 },
                 nextDay: {
-                  tpl: createButton('nextDay', 'Next Date', 'M15 10 L25 20 L15 30'),
+                  tpl: createButton('nextDate', 'Next Date', 'M15 10 L25 20 L15 30'),
                   click: () => {
                       stepDate(1);
                   },
@@ -417,7 +417,7 @@ jQuery(window).on('load', function () {
             }),
         },
         display: {
-          ...(isCalendarFormat() && { middle: ["previousDay", "nextDay"] }),
+          ...(isCalendarFormat() && { middle: ["previousDate", "nextDate"] }),
           right: [
                 'toggleZoom',
                 'download',

--- a/js/gwbootstrap-extra.js
+++ b/js/gwbootstrap-extra.js
@@ -402,13 +402,13 @@ jQuery(window).on('load', function () {
       Toolbar: {
         items: {
             ...(isCalendarFormat() && {
-                previousDay: {
+                previousDate: {
                   tpl: createButton('previousDate', 'Previous Date', 'M25 10 L15 20 L25 30'), 
                   click: () => {
                         stepDate(-1);
                     },
                 },
-                nextDay: {
+                nextDate: {
                   tpl: createButton('nextDate', 'Next Date', 'M15 10 L25 20 L15 30'),
                   click: () => {
                       stepDate(1);
@@ -417,11 +417,13 @@ jQuery(window).on('load', function () {
             }),
         },
         display: {
-          ...(isCalendarFormat() && { middle: ["previousDate", "nextDate"] }),
+          middle: isCalendarFormat() ? ["previousDate", "nextDate"] : [],
           right: [
-                'toggleZoom',
-                'download',
-                'slideshow',
+            'toggleZoom',
+            'download',
+            'slideshow',
+            'thumbs',
+            'close',
             ],
         },
     }

--- a/js/gwbootstrap-extra.js
+++ b/js/gwbootstrap-extra.js
@@ -132,6 +132,44 @@ function shortenDate() {
   }
 }
 
+
+/* ------------------------------------------------------------------------- */
+/* Summary Pages custom buttons                                              */
+
+  /**
+   * Creates an HTML button element with an SVG icon.
+   *
+   * @param {string} label - The label used for the button's class and data attributes.
+   * @param {string} title - The title attribute for the button.
+   * @param {string} svgPathData - The SVG path data used to draw the icon inside the button.
+   * @returns {string} - The HTML string representing the button with the SVG icon.
+   */
+
+  function createButton(label, title, svgPathData) {
+    const buttonHTML = 
+        '<button class="f-button fancybox-button--' + label + '" data-fancybox-' + label + ' title="' + title + '">' +
+            '<svg viewBox="0 0 40 40">' +
+                '<path d="' + svgPathData + '" />' +
+            '</svg>' +
+        '</button>';
+    
+    return buttonHTML;
+}
+  /**
+   * Checks if the current date format is a calendar format.
+   *
+   * This function retrieves the current date format
+   * and checks if it is one of the calendar formats:
+   * 'day', 'week', 'month', or 'year'.
+   *
+   * @returns {boolean} - Returns true if the date format is a calendar format, otherwise false.
+   */
+  function isCalendarFormat() {
+    const dateformat = findDateFormat();
+    const periodicFormats = ['day', 'week', 'month', 'year'];
+    return periodicFormats.includes(dateformat);
+  }
+
 /* ------------------------------------------------------------------------- */
 /* Fancybox images                                                           */
 
@@ -331,6 +369,62 @@ jQuery(window).on('load', function () {
     title: this.title,
     href: jQuery(this).attr('href'),
     type: 'iframe',
+  });
+
+
+  /**
+   * Initializes Fancybox for elements with the `data-fancybox="summary"` attribute.
+   * This configuration is specifically designed for Summary Pages.
+   *
+   * Binds Fancybox to gallery items and customizes the toolbar with two buttons:
+   * - A "previousDay" button for navigating to the previous day.
+   * - A "nextDay" button for navigating to the next day.
+   *
+   * Clicking either button updates the page URL to reflect the selected date.
+   * As the gallery image is open, the new page will automatically open the 
+   * gallery with the same image number.
+   * 
+   * The new buttons are just created for the calendar data formats:
+   * 'day', 'week', 'month', or 'year'.
+   */
+
+
+  Fancybox.bind('[data-fancybox="summary"]', {
+      contentClick: 'toggleZoom',
+      placeFocusBack: false,
+      Images: {
+        initialSize: 'fit',
+      },
+      Thumbs: {
+        showOnStart: false,
+        type: 'classic',
+      },
+      Toolbar: {
+        items: {
+            ...(isCalendarFormat() && {
+                previousDay: {
+                  tpl: createButton('previousDay', 'Previous Date', 'M25 10 L15 20 L25 30'), 
+                  click: () => {
+                        stepDate(-1);
+                    },
+                },
+                nextDay: {
+                  tpl: createButton('nextDay', 'Next Date', 'M15 10 L25 20 L15 30'),
+                  click: () => {
+                      stepDate(1);
+                  },
+              },
+            }),
+        },
+        display: {
+          ...(isCalendarFormat() && { middle: ["previousDay", "nextDay"] }),
+          right: [
+                'toggleZoom',
+                'download',
+                'slideshow',
+            ],
+        },
+    }
   });
 
   // reposition dropdown if scrolling off the screen


### PR DESCRIPTION
This update enhances the Fancybox initialization for elements with the `data-fancybox="summary"` attribute, tailored specifically for Summary Pages. The configuration now includes two custom toolbar buttons, "previousDate" and "nextDate," which facilitate navigation between calendar dates (day, week, month, or year) within the gallery. These buttons dynamically update the page URL to reflect the selected date and automatically reopen the gallery on the same image upon navigation. 

Running example: https://ldas-jobs.ligo-la.caltech.edu/~iara.ota/summary/day/20240801/sei/ground_blrms_overview/

GPS mode example: https://ldas-jobs.ligo-la.caltech.edu/~iara.ota/summary/gps/1406332818-1406410218/sei/ground_blrms_overview/